### PR TITLE
Update xml.py - Isolate hop project from application

### DIFF
--- a/airflow_hop/xml.py
+++ b/airflow_hop/xml.py
@@ -45,7 +45,10 @@ class XMLBuilder:
         project = next(item for item in config_data['projectsConfig']['projectConfigurations']
             if item['projectName'] == project_name)
         self.project_home = project['projectHome']
-        self.project_folder = f'{hop_home}/{project["projectHome"]}'
+        if hop_home == self.project_home:
+            self.project_folder = self.project_home
+        else:
+            self.project_folder = f'{hop_home}/{self.project_home}'
         self.metastore_file = f'{self.project_folder}/metadata.json'
 
         with open(f'{self.project_folder}/{project["configFilename"]}') as file:


### PR DESCRIPTION
Hello.

Sorry for the English, I used google translator.

I would like to suggest a change to the xml.py file.

According to the documentation, it would be necessary to leave the hop artifacts in the home_home/project folder for the plugin to work correctly.

Analyzing the code I thought and tested the following solution.

the commented line is the original of the project and the line below is the change suggestion

#self.project_folder = f'{hop_home}/{project["projectHome"]}'

if hop_home == self.project_home:
self.project_folder = self.project_home
else:
self.project_folder = f'{hop_home}/{self.project_home}'

This way I can leave the hop project isolated from the hop application, gaining mobility.

for the documentation you could leave it like this:
If your project is in a custom location, in the apache airflow connection configuration, home_home must be the same as the folder where your project is, so the plugin works correctly.

Attention: it is necessary that the hop artifacts are in the Airflow container, in the same path.

![image](https://user-images.githubusercontent.com/70301866/204293009-9f6e00f5-6373-4714-b140-9c5f77824835.png)

![image](https://user-images.githubusercontent.com/70301866/204293052-e0760ba3-a73f-47b4-8fb8-f02e13fe0d8f.png)


