### PR TITLE
Fix correct param passing from Airflow (version >2.3.3) to HOP

### DIFF
--- a/airflow_hop/operators.py
+++ b/airflow_hop/operators.py
@@ -57,14 +57,14 @@ class HopWorkflowOperator(HopBaseOperator):
                  log_level,
                  *args,
                  environment=None,
-                 params=None,
+                 hop_params=None,
                  hop_conn_id='hop_default',
                  **kwargs):
         super().__init__(*args, **kwargs)
         self.workflow = workflow
         self.project_name = project_name
         self.log_level = log_level
-        self.task_params = params
+        self.task_params = hop_params
         self.hop_conn_id = hop_conn_id
         self.environment = environment
 
@@ -120,7 +120,7 @@ class HopPipelineOperator(HopBaseOperator):
                  log_level,
                  *args,
                  environment=None,
-                 params=None,
+                 hop_params=None,
                  hop_conn_id='hop_default',
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -129,7 +129,7 @@ class HopPipelineOperator(HopBaseOperator):
         self.project_name = project_name
         self.log_level = log_level
         self.hop_conn_id = hop_conn_id
-        self.task_params = params
+        self.task_params = hop_params
         self.environment = environment
 
     def __get_hop_client(self):


### PR DESCRIPTION
**Description**
**Issue**
There was an issue with passing parameters and macro variables from Apache Airflow to Apache HOP. The parameters were not being correctly interpreted in the HOP logs, showing the raw macro variable names (e.g., {{ ds }}) instead of their expected values (e.g., 20-05-2024).

**Solution**
Changed the parameter name from param to **hop_param**. This adjustment ensures compatibility and correct macro convertion in HOP logs.

**Additional Information**
In Apache Airflow 2.3.3, the params variable is utilized during DAG serialization. Using params as a variable name in third-party operators can lead to issues. For more information, refer to the [Apache Airflow Pull Request #20640](https://github.com/apache/airflow/pull/20640/files/03550d26654f77bbcd91b44a1372320cb48bda6e)


