### PR TITLE
Add PROJECT_HOME variable to resolve sub-workflow/pipeline resolution issues

### DIFF
--- a/airflow_hop/xml.py
+++ b/airflow_hop/xml.py
@@ -211,6 +211,7 @@ class XMLBuilder:
         project_home = Element('variable')
         project_home.append(self.__generate_element('name','PROJECT_HOME'))
         project_home.append(self.__generate_element('value',self.project_home))
+        root.append(project_home)
 
         jdk_debug = Element('variable')
         jdk_debug.append(self.__generate_element('name','jdk.debug'))


### PR DESCRIPTION
## Fix for sub-workflows and sub-pipelines in non-default projects

This PR addresses an issue where workflows containing sub-workflows or sub-pipelines would fail when run from projects with different names than the default Apache HOP project.

### Problem
When running workflows from non-default projects that contain sub-workflows or sub-pipelines, Apache HOP couldn't locate these sub-components because it was falling back to the default project path instead of using the actual project path.

### Solution
Added the PROJECT_HOME variable to the execution context, allowing Apache HOP to correctly resolve paths to sub-workflows and sub-pipelines within the current project structure.

### Testing
Tested with workflows containing sub-workflows and sub-pipelines in a custom-named project, and they now execute successfully.